### PR TITLE
Add travis ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@
 
 !.gitignore
 !.gitkeep
-
+!.travis.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: php
+
+php:
+  - 5.5
+  - 5.6
+  - 7.0
+  - 7.1
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+install:
+    - composer update --prefer-dist --no-interaction
+
+script:
+    - ./vendor/bin/phpunit --coverage-text

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,6 +10,9 @@
          stopOnFailure="false"
          syntaxCheck="false">
     <testsuites>
+        <testsuite name="Shell Command Test Suite">
+            <directory>tests/</directory>
+        </testsuite>
     </testsuites>
     <filter>
     </filter>


### PR DESCRIPTION
Hey

I added [travis](https://travis-ci.org) config to assure the stability of the library. The tests are currently red as seen [here](https://travis-ci.org/nickel715/shell-command/jobs/324557167) but in #2 this will be fixed.

To enable travis after merging this pull request you just need to login to travis with your github account and enable the shell-command repository.

We would be really appreciated if you integrate travis together with us.
  